### PR TITLE
fix(regex): update regex

### DIFF
--- a/tasks/cdn_nobuild.js
+++ b/tasks/cdn_nobuild.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
     var options = this.options({
     });
 
-    var cdnTagsRe = /(<script\ssrc\s*=\s*['"](?:[a-zA-Z]+?:)?\/\/[^<]+<\/script>)|(<link\s+(?:\w*=['"].*?['"])*?\s+href\s*=\s*['"](?:[a-zA-Z]+:)?\/\/[^<>]+?\/?>)/gim;
+    var cdnTagsRe = /(<script\ssrc\s*=\s*['"](?:[a-zA-Z]+?:)?\/\/[^<]+<\/script>)|(<link(?:\s+\w*=['"].*?['"])*?\s+href\s*=\s*['"](?:[a-zA-Z]+:)?\/\/[^<>]+?\/?>)/gim;
     var buildSectionBeginRe = /<!--\s*build:/gim;
     var buildSectionEndRe = /<!--\s*endbuild/gim;
 


### PR DESCRIPTION
if `href` is the first element in a `<link>` tag, the regex will fail to
match because there is only one space but two `\s+`
